### PR TITLE
quick fix

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,5 +1,6 @@
 import { Component } from '@angular/core';
 import { log } from './kaop-test';
+import { beforeMethod } from 'kaop-ts';
 
 @Component({
   selector: 'app-root',
@@ -9,7 +10,7 @@ import { log } from './kaop-test';
 export class AppComponent {
   title = 'kaop-test';
 
-  @log()
+  @beforeMethod(log)
   decoratorTest(testString: string): void {
     console.log('hello');
   }

--- a/src/app/kaop-test.ts
+++ b/src/app/kaop-test.ts
@@ -1,7 +1,4 @@
-import { beforeMethod } from 'kaop-ts';
 
-export function log() {
-  return beforeMethod(meta => {
-    console.log('annotation logging...');
-  });
+export const log = meta => {
+  console.log('annotation logging...');
 }


### PR DESCRIPTION
seems that aot has banned function calls on decorators, so this is a work around that kills modularity